### PR TITLE
fix: Update README to remove duplicate badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,8 @@
   <a href="https://github.com/OlegZv/machineq/actions/workflows/main.yml?query=branch%3Amain">
     <img src="https://img.shields.io/github/actions/workflow/status/OlegZv/machineq/main.yml?branch=main&label=Build/Test/Lint" alt="Build/Test/Lint status" />
   </a>
-
-  <a href="https://github.com/OlegZv/machineq/actions/workflows/main.yml?query=branch%3Amain">
-    <img src="https://img.shields.io/github/actions/workflow/status/OlegZv/machineq/main.yml?branch=main" alt="Build status" />
-  </a>
   <a href="https://codecov.io/gh/OlegZv/machineq">
     <img src="https://codecov.io/gh/OlegZv/machineq/branch/main/graph/badge.svg" alt="codecov" />
-  </a>
-  <a href="https://img.shields.io/github/commit-activity/m/OlegZv/machineq">
-    <img src="https://img.shields.io/github/commit-activity/m/OlegZv/machineq" alt="Commit activity" />
   </a>
   <a href="https://img.shields.io/github/license/OlegZv/machineq">
     <img src="https://img.shields.io/github/license/OlegZv/machineq" alt="License" />
@@ -26,11 +19,11 @@
 
 ## Installation
 
-Recommended installation using `uv add machineq` (or via pip" `pip install machineq`)
+Recommended installation using `uv add machineq` (or via pip `pip install machineq`)
 
 ## Example Usage
 
-For more examples and API reference check out [the quickstart section](https://machineq.readthedocs.io/en/latest/quickstart/) and [usage](https://machineq.readthedocs.io/en/latest/usage/clients/).
+For more examples and API reference, check out [the quickstart section](https://machineq.readthedocs.io/en/latest/quickstart/) and [usage](https://machineq.readthedocs.io/en/latest/usage/clients/).
 
 Here is a simple example of getting the list of devices on the subscriber using `SyncClient`:
 


### PR DESCRIPTION
Removed duplicate build status badge and commit activity badge from README.